### PR TITLE
Fix gallery download interruption causing blob URL navigation

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Reddit Download Buttons
 // @description  Adds buttons to easily download images/videos from Reddit
-// @version      1.4.4
+// @version      1.4.5
 // @author       Alexander Bays (956MB)
 // @namespace    https://github.com/956MB/reddit-download-button
 // @match        https://*.reddit.com/*
@@ -640,6 +640,9 @@
         a.href = URL.createObjectURL(blob);
         a.download = filename;
         document.body.appendChild(a);
+        a.addEventListener('click', (e) => {
+            e.stopPropagation();
+        });
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(a.href);


### PR DESCRIPTION
### Description
Fixed an issue where downloading a gallery (multi-image post) would stop after the first image.

### The Problem
When attempting to download a gallery:
1. The script starts cycling through images.
2. The first image downloads successfully.
3. Immediately after, the browser's address bar changes to a `blob:https://www.reddit.com/...` URL.
4. The script execution stops, and subsequent images are not downloaded.

### Root Cause
Reddit's SPA (Single Page Application) router intercepts the click event on the temporary `<a>` element used in the `saveBlob` function. Instead of just downloading the file, Reddit attempts to "navigate" to the blob URL, treating it as an internal link.

### The Fix
Added `e.stopPropagation()` to the click event listener on the temporary anchor element. This prevents the event from bubbling up to Reddit's router, allowing the download to proceed without triggering a page navigation.

### Environment
- **Browser:** Firefox 146.0
- **Manager:** Tampermonkey 5.4.1